### PR TITLE
Fix missing package name

### DIFF
--- a/src/main/java/com/kila/apprater_dialog/lars/AppRater.java
+++ b/src/main/java/com/kila/apprater_dialog/lars/AppRater.java
@@ -125,6 +125,7 @@ public class AppRater {
 
         protected AppRaterDialog.Builder buildAppRaterDialog() {
             AppRaterDialog.Builder builder = new AppRaterDialog.Builder(context);
+            builder.setPackageName(packageName);
             if (title != null)
                 builder.setTitle(title);
             if (message != null)


### PR DESCRIPTION
When AppRatedDialog was created, you forger to provide packageName.